### PR TITLE
Add Helper Functions for FSIR

### DIFF
--- a/R/discretize.R
+++ b/R/discretize.R
@@ -1,0 +1,43 @@
+#' Discretize Response
+#'
+#' \code{discretize} converts the response into a discrete form by creating slices and assigning each part of the response to the slice it is in.
+#'
+#' This function converts a vector response into a vector of the slices each value in the response is a part of. This is important for the Functional Sliced Inverse Regression method which relies on using these slices for reducing the dimension of data.
+#'
+#' @param y A vector representing the response variable
+#' @param yunit A vector defining the slices used
+#'
+#' @return A vector defining the slices each item in the response corresponds to
+#'
+#' @noRd
+#' @examples
+#' y -> c(1, 2, 3, 2)
+#' yunit -> unique(y)
+#'
+discretize <- function(y, yunit) {
+  n <- length(y)
+  #Add small amount of noise to y
+  y <- y + .00001 * mean(y) * rnorm(n)
+  nsli <- length(yunit)
+  #order y values in ascending order
+  yord <- y[order(y)]
+  n <- length(y)
+  nwith <- floor(n / nsli)
+  #instantiate vector of division points between slices
+  divpt <- rep(0, nsli - 1)
+  #set each division point to the values of yord that
+  #represent the boundaries between slices
+  for(i in 1:(nsli - 1)) {
+    divpt[i] <- yord[i * nwith + 1] }
+
+  y1 <- rep(0, n)
+  #Assign slice labels to the upper boundary slice
+  y1[y >= divpt[nsli - 1]] <- nsli
+  #Assign slice labels to the lower boundary slice
+  y1[y < divpt[1]] <- 1
+  #Assign slices labels to intermediate slices
+  for(i in 2:(nsli - 1)) {
+    y1[(y >= divpt[i - 1]) & (y < divpt[i])] <- i }
+  #return discretized y
+  return(y1)
+}

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -1,8 +1,12 @@
 #' Discretize Response
 #'
-#' \code{discretize} converts the response into a discrete form by creating slices and assigning each part of the response to the slice it is in.
+#' \code{discretize} converts the response into a discrete form by creating
+#' slices and assigning each part of the response to the slice it is in.
 #'
-#' This function converts a vector response into a vector of the slices each value in the response is a part of. This is important for the Functional Sliced Inverse Regression method which relies on using these slices for reducing the dimension of data.
+#' This function converts a vector response into a vector of the slices each
+#' value in the response is a part of. This is important for the Functional
+#' Sliced Inverse Regression method which relies on using these slices for
+#' reducing the dimension of data.
 #'
 #' @param y A vector representing the response variable
 #' @param yunit A vector defining the slices used

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -17,31 +17,33 @@
 #' @examples
 #' y -> c(1, 2, 3, 2)
 #' yunit -> unique(y)
-#'
+#' discretize(y, yunit)
 discretize <- function(y, yunit) {
   n <- length(y)
-  #Add small amount of noise to y
+  # Add small amount of noise to y
   y <- y + .00001 * mean(y) * rnorm(n)
   nsli <- length(yunit)
-  #order y values in ascending order
+  # Order y values in ascending order
   yord <- y[order(y)]
   n <- length(y)
-  nwith <- floor(n / nsli)
-  #instantiate vector of division points between slices
+  nwidth <- floor(n / nsli)
+  # Instantiate vector of division points between slices
   divpt <- rep(0, nsli - 1)
-  #set each division point to the values of yord that
-  #represent the boundaries between slices
+  # Set each division point to the values of yord that represent the boundaries
+  # between slices
   for(i in 1:(nsli - 1)) {
-    divpt[i] <- yord[i * nwith + 1] }
+    divpt[i] <- yord[i * nwidth + 1]
+  }
 
   y1 <- rep(0, n)
-  #Assign slice labels to the upper boundary slice
+  # Assign slice labels to the upper boundary slice
   y1[y >= divpt[nsli - 1]] <- nsli
-  #Assign slice labels to the lower boundary slice
+  # Assign slice labels to the lower boundary slice
   y1[y < divpt[1]] <- 1
-  #Assign slices labels to intermediate slices
+  # Assign slices labels to intermediate slices
   for(i in 2:(nsli - 1)) {
-    y1[(y >= divpt[i - 1]) & (y < divpt[i])] <- i }
-  #return discretized y
-  return(y1)
+    y1[(y >= divpt[i - 1]) & (y < divpt[i])] <- i
+  }
+  # Return discretized y
+  y1
 }

--- a/R/discretize.R
+++ b/R/discretize.R
@@ -19,6 +19,17 @@
 #' yunit -> unique(y)
 #' discretize(y, yunit)
 discretize <- function(y, yunit) {
+
+  # Check if y is a vector
+  if (!is.vector(y)) {
+    stop("y must be a vector.")
+  }
+
+  # Check if yunit is a vector
+  if (!is.vector(yunit)) {
+    stop("yunit must be a vector.")
+  }
+
   n <- length(y)
   # Add small amount of noise to y
   y <- y + .00001 * mean(y) * rnorm(n)

--- a/R/slav.R
+++ b/R/slav.R
@@ -1,6 +1,6 @@
 #' Compute slice average
 #'
-#' \code{slav} computes slice average
+#' \code{slav} computes the slice average.
 #'
 #' Creates a matrix of slice average by using x coordinates, a discretized
 #' response, and number of slices. For each slice, the rows of x coefficients
@@ -8,24 +8,36 @@
 #' applied to them column-wise to compute the average of x coefficient for each
 #' slice.
 #'
-#' @param xcoefs coordinates of X
-#' @param y discretized response
-#' @param yunit number of slices
+#' @param xcoefs Coordinates of X
+#' @param y The discretized vector for the response variable
+#' @param yunit A vector defining the slices used
 #'
-#' @return matrix of slice average
+#' @return Matrix of slice average
 #' @noRd
 #'
 #' @examples
 #' xcoefs <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
 #'   nrow = 4, byrow= TRUE)
-#' y <- (1, 2 , 3, 2)
+#' y <- c(1, 2, 3, 2)
 #' yunit <- unique(y)
 slav <- function(xcoefs, y, yunit) {
+  # Get dimensions of xcoefs
   n <- nrow(xcoefs)
   K <- ncol(xcoefs)
+  # Get number of slices
   nslice <- length(yunit)
+  # Initialize matrix of mean coordinates for each slice
   xcoefsgy <- matrix(0, nslice, K)
   for(i in 1:nslice) {
-    xcoefsgy[i, ] <- apply(xcoefs[y==yunit[i], ], 2, mean) }
-  return(xcoefsgy)
+    # Store predictors for each slice
+    predictors <- xcoefs[y == yunit[i], ]
+    # If vector, convert to horizontal matrix
+    if (is.vector(predictors)) {
+      predictors <- t(as.matrix(predictors))
+    }
+    # Calculate mean for each slice
+    xcoefsgy[i, ] <- apply(predictors, 2, mean)
+  }
+  # Return mean coordinates for the predictors
+  xcoefsgy
 }

--- a/R/slav.R
+++ b/R/slav.R
@@ -20,6 +20,7 @@
 #'   nrow = 4, byrow= TRUE)
 #' y <- c(1, 2, 3, 2)
 #' yunit <- unique(y)
+#' slav(xcoefs, y, yunit)
 slav <- function(xcoefs, y, yunit) {
   # Get dimensions of xcoefs
   n <- nrow(xcoefs)

--- a/R/slav.R
+++ b/R/slav.R
@@ -22,6 +22,24 @@
 #' yunit <- unique(y)
 #' slav(xcoefs, y, yunit)
 slav <- function(xcoefs, y, yunit) {
+
+  # Check to ensure xcoefs is a matrix
+  if (!is.matrix(xcoefs)){
+    stop("The x coefficients are not in matrix form")
+  }
+
+  if (!is.vector(y)) {
+    stop("y must be a vector.")
+  }
+  if (!is.vector(yunit)) {
+    stop("yunit must be a vector.")
+  }
+  for (i in y) {
+    if(!(i %in% yunit)) {
+      stop(paste("y must be discretized such that all values in y are in",
+                 "yunit. The value", i, "is not in yunit."))
+    }
+  }
   # Get dimensions of xcoefs
   n <- nrow(xcoefs)
   K <- ncol(xcoefs)

--- a/R/slav.R
+++ b/R/slav.R
@@ -1,0 +1,31 @@
+#' Compute slice average
+#'
+#' \code{slav} computes slice average
+#'
+#' Creates a matrix of slice average by using x coordinates, a discretized
+#' response, and number of slices. For each slice, the rows of x coefficients
+#' where y equals the current slice value of y unit at i get the mean function
+#' applied to them column-wise to compute the average of x coefficient for each
+#' slice.
+#'
+#' @param xcoefs coordinates of X
+#' @param y discretized response
+#' @param yunit number of slices
+#'
+#' @return matrix of slice average
+#' @noRd
+#'
+#' @examples
+#' xcoefs <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12),
+#'   nrow = 4, byrow= TRUE)
+#' y <- (1, 2 , 3, 2)
+#' yunit <- unique(y)
+slav <- function(xcoefs, y, yunit) {
+  n <- nrow(xcoefs)
+  K <- ncol(xcoefs)
+  nslice <- length(yunit)
+  xcoefsgy <- matrix(0, nslice, K)
+  for(i in 1:nslice) {
+    xcoefsgy[i, ] <- apply(xcoefs[y==yunit[i], ], 2, mean) }
+  return(xcoefsgy)
+}

--- a/R/slprob.R
+++ b/R/slprob.R
@@ -25,7 +25,7 @@ slprob <- function(y, yunit) {
   out <- rep(0, nslice)
   for (i in 1:nslice) {
     # Probabilty = number of points in slice / number of points
-    out[i] <- length(y[y==yunit[i]]) / n
+    out[i] <- length(y[y == yunit[i]]) / n
   }
   # Return output vector
   out

--- a/R/slprob.R
+++ b/R/slprob.R
@@ -15,6 +15,7 @@
 #'
 #' @noRd
 #' @examples
+#' slprob(c(1,1,2,3,3,2,1,2),1:3)
 slprob <- function(y, yunit) {
   # Get length of y vector
   n <- length(y)

--- a/R/slprob.R
+++ b/R/slprob.R
@@ -17,6 +17,19 @@
 #' @examples
 #' slprob(c(1,1,2,3,3,2,1,2),1:3)
 slprob <- function(y, yunit) {
+  if (!is.vector(y)) {
+    stop("y must be a vector.")
+  }
+  if (!is.vector(yunit)) {
+    stop("yunit must be a vector.")
+  }
+  for (i in y) {
+    if(!(i %in% yunit)) {
+      stop(paste("y must be discretized such that all values in y are in",
+                 "yunit. The value", i, "is not in yunit."))
+    }
+  }
+
   # Get length of y vector
   n <- length(y)
   # Get number of slices from yunit

--- a/R/slprob.R
+++ b/R/slprob.R
@@ -1,0 +1,31 @@
+#' Slice Probabilities
+#'
+#' \code{slprob} calculates the probability that a given response will be in
+#' each slice.
+#'
+#' This function takes in a discretized y vector and a vector determining the
+#' values at each slice (usually a range 1:H where H is the number of slices)
+#' to determine the proportion of the observed responses in each slice to
+#' determine the probablity that a given y will be within that slice.
+#'
+#' @param y The discretized vector for the response variable
+#' @param yunit A vector defining the slices used
+#'
+#' @return A vector of probabilities that a response will be in each slice
+#'
+#' @noRd
+#' @examples
+slprob <- function(y, yunit) {
+  # Get length of y vector
+  n <- length(y)
+  # Get number of slices from yunit
+  nslice <- length(yunit)
+  # Define new vector for output
+  out <- rep(0, nslice)
+  for (i in 1:nslice) {
+    # Probabilty = number of points in slice / number of points
+    out[i] <- length(y[y==yunit[i]]) / n
+  }
+  # Return output vector
+  out
+}

--- a/R/symmetry.R
+++ b/R/symmetry.R
@@ -1,0 +1,17 @@
+#' Symmetrize Matrix
+#'
+#' \code{symmetry} makes a matrix symmetrical while retaining the most
+#' properties possible of the original matrix.
+#'
+#' The function finds the average between a matrix and its transpose to create
+#' a symmetrical matrix while retaining properties such as the mean and
+#'
+#' @param a
+#'
+#' @return
+#' @export
+#'
+#' @examples
+symmetry <- function(a) {
+  (a + t(a)) / 2
+}

--- a/R/symmetry.R
+++ b/R/symmetry.R
@@ -4,13 +4,13 @@
 #' properties possible of the original matrix.
 #'
 #' The function finds the average between a matrix and its transpose to create
-#' a symmetrical matrix while retaining properties such as the mean and
+#' a symmetrical matrix while retaining properties such as the mean.
 #'
-#' @param a
+#' @param a The matrix to symmetrize
 #'
-#' @return
-#' @export
+#' @return A symmetric matrix based on the matrix \code{a}
 #'
+#' @noRd
 #' @examples
 #' testMatrix <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9), nrow = 3, ncol = 3)
 #' symmetry(testMatrix)

--- a/R/symmetry.R
+++ b/R/symmetry.R
@@ -15,5 +15,11 @@
 #' testMatrix <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9), nrow = 3, ncol = 3)
 #' symmetry(testMatrix)
 symmetry <- function(a) {
+  if (!is.matrix(a)) {
+    stop("a must be a matrix.")
+  }
+  if (nrow(a) != ncol(a)) {
+    stop("a must be a square matrix.")
+  }
   (a + t(a)) / 2
 }

--- a/R/symmetry.R
+++ b/R/symmetry.R
@@ -12,6 +12,8 @@
 #' @export
 #'
 #' @examples
+#' testMatrix <- matrix(c(1, 2, 3, 4, 5, 6, 7, 8, 9), nrow = 3, ncol = 3)
+#' symmetry(testMatrix)
 symmetry <- function(a) {
   (a + t(a)) / 2
 }


### PR DESCRIPTION
This pull request adds the following functions:

* `slav`
* `slprob`
* `discretize`
* `symmetry`

In addition to the pre-written code, we added checks to the functions to verify that valid inputs were added and modified some of the code for cleanliness and error handling. We also documented the functions.

Specifically, `discretize` requires `y` and `yunit` to be vectors, as do `slav` and `slprob`. Additionally, `slav` and `slprob` require `y` to only contain values in `yunit` and `slav` requires `xcoefs` to be matrix. And lastly, `symmetry` requires `a` to be a square matrix.

Additionally, in `slav`, code was added to handle cases where only one value of the response is in a given slice. This would not be ideal, but when using the example we created for the function, this resulted in an error as `xcoefs[y == yunit[i], ]` returned a vector instead of a matrix. So, the code converts this to a horizontal matrix if a vector is returned.

We also are considering replacing `yunit` with a parameter for the number of slices in the future to make it more likely that the function will be used correctly, but this would be implemented in future changes rather than now.