### PR TITLE
Use Stats Namespace for `rnorm`

### DIFF
--- a/R/discretize.R
+++ b/R/discretize.R
@@ -32,7 +32,7 @@ discretize <- function(y, yunit) {
 
   n <- length(y)
   # Add small amount of noise to y
-  y <- y + .00001 * mean(y) * rnorm(n)
+  y <- y + .00001 * mean(y) * stats::rnorm(n)
   nsli <- length(yunit)
   # Order y values in ascending order
   yord <- y[order(y)]


### PR DESCRIPTION
This pull request is intended to remove the note for the `discretize` function by directly declaring the namespace `stats` for `rnorm` by utilizing `stats::rnorm` instead of `rnorm`. During testing, the update results in 0 notes with the only 3 warnings coming from the `hello` function for testing, the lack of a license, and the `@noRd` flag for the functions.